### PR TITLE
Support syntax change for call in Ruby 2.6

### DIFF
--- a/lib/sorcerer/resource.rb
+++ b/lib/sorcerer/resource.rb
@@ -460,7 +460,7 @@ module Sorcerer
       },
       :call => lambda { |sexp|
         resource(sexp[1])
-        emit(sexp[2])
+        resource(sexp[2])
         resource(sexp[3]) unless sexp[3] == :call
       },
       :case => lambda { |sexp|


### PR DESCRIPTION
 In Ruby 2.5.5, Ripper::SexpBuilder.new(thing.stuff).parse gives this output:

[:program,
 [:stmts_add,
  [:stmts_new],
  [:call,
   [:vcall, [:@ident, thing, [1, 0]]],
   :.,
   [:@ident, stuff, [1, 6]]]]]

 but in Ruby 2.6.2, it gives this output:

 [:program,
 [:stmts_add,
  [:stmts_new],
  [:call,
   [:vcall, [:@ident, thing, [1, 0]]],
   [:@period, ., [1, 5]],
   [:@ident, stuff, [1, 6]]]]]

This means it is no longer safe to assume that the third item in the :call array can be emitted without any processing, and we need to call resource on it